### PR TITLE
Allow hijacking of getUserMedia() without videoIds

### DIFF
--- a/js/media-devices.js
+++ b/js/media-devices.js
@@ -23,10 +23,13 @@ function monkeyPatchMediaDevices() {
 
   MediaDevices.prototype.getUserMedia = async function (userConstrains, ...args) {
     console.log(userConstrains);
-    if (userConstrains && userConstrains.video && userConstrains.video.deviceId) {
+    const video = userConstrains && userConstrains.video;
+    if (video) {
       if (
-        userConstrains.video.deviceId === "virtual" ||
-        userConstrains.video.deviceId.exact === "virtual"
+        window.videoHijack ||
+        video.deviceId && (
+        video.deviceId === "virtual" ||
+        video.deviceId.exact === "virtual")
       ) {
         // This constraints could mimick closely the request.
         // Also, there could be a preferred webcam on the options.
@@ -34,9 +37,9 @@ function monkeyPatchMediaDevices() {
         const constraints = {
           video: {
             facingMode: userConstrains.facingMode,
-            advanced: userConstrains.video.advanced,
-            width: userConstrains.video.width,
-            height: userConstrains.video.height,
+            advanced: video.advanced,
+            width: video.width,
+            height: video.height,
           },
           audio: false,
         };

--- a/js/media-devices.js
+++ b/js/media-devices.js
@@ -21,23 +21,22 @@ function monkeyPatchMediaDevices() {
     return res;
   };
 
-  MediaDevices.prototype.getUserMedia = async function () {
-    const args = arguments;
-    console.log(args[0]);
-    if (args.length && args[0].video && args[0].video.deviceId) {
+  MediaDevices.prototype.getUserMedia = async function (userConstrains, ...args) {
+    console.log(userConstrains);
+    if (userConstrains && userConstrains.video && userConstrains.video.deviceId) {
       if (
-        args[0].video.deviceId === "virtual" ||
-        args[0].video.deviceId.exact === "virtual"
+        userConstrains.video.deviceId === "virtual" ||
+        userConstrains.video.deviceId.exact === "virtual"
       ) {
         // This constraints could mimick closely the request.
         // Also, there could be a preferred webcam on the options.
         // Right now it defaults to the predefined input.
         const constraints = {
           video: {
-            facingMode: args[0].facingMode,
-            advanced: args[0].video.advanced,
-            width: args[0].video.width,
-            height: args[0].video.height,
+            facingMode: userConstrains.facingMode,
+            advanced: userConstrains.video.advanced,
+            width: userConstrains.video.width,
+            height: userConstrains.video.height,
           },
           audio: false,
         };
@@ -51,7 +50,7 @@ function monkeyPatchMediaDevices() {
         }
       }
     }
-    const res = await getUserMediaFn.call(navigator.mediaDevices, ...arguments);
+    const res = await getUserMediaFn.call(navigator.mediaDevices, userConstrains, ...args);
     return res;
   };
 


### PR DESCRIPTION
for example, some sites may call

```js
getUserMedia({video:
  facingMode: "user"
  frameRate: 15
  height: 360
  width: 640
}
```
without videoId. If `window.videoHijack` is set to true, allow virtual-webcam to attempt hostile takeover